### PR TITLE
Migrating all repositories over to github away from codeCommit

### DIFF
--- a/lib/PipelineStack.ts
+++ b/lib/PipelineStack.ts
@@ -5,6 +5,8 @@ import * as codePipeline from "aws-cdk-lib/aws-codepipeline";
 import * as codeCommit from 'aws-cdk-lib/aws-codecommit';
 import * as codePipelineActions from "aws-cdk-lib/aws-codepipeline-actions";
 import * as codeCommitActions from "aws-cdk-lib/aws-codepipeline-actions";
+import * as secrets from "aws-cdk-lib/aws-secretsmanager";
+import {GitHubTrigger} from "aws-cdk-lib/aws-codepipeline-actions";
 import * as cf from "aws-cdk-lib/aws-cloudfront";
 import {Construct} from "constructs";
 
@@ -32,6 +34,13 @@ export class PipelineStack extends cdk.Stack {
       branchOrRef: 'main'
     });
 
+    const githubSource = codebuild.Source.gitHub({
+      owner: 'CallMeCCLemon',
+      repo: 'TheDailyAbstractionWebsiteAssets',
+      webhook: true,
+      branchOrRef: 'main'
+    });
+
     const buildSpec = this.getBuildSpec();
     const project = new codebuild.Project(this, 'blog-website-assets-code-build-project', {
       source,
@@ -42,12 +51,27 @@ export class PipelineStack extends cdk.Stack {
       buildSpec
     });
 
+    const githubProject = new codebuild.Project(this, 'github-website-assets-code-build-project', {
+      source: githubSource,
+      environment: {
+        buildImage: codebuild.LinuxBuildImage.STANDARD_6_0,
+        privileged: true,
+      },
+      buildSpec
+    });
+
     this.websiteAssetsS3Bucket.grantReadWrite(project.grantPrincipal);
+    this.websiteAssetsS3Bucket.grantReadWrite(githubProject.grantPrincipal);
 
     const artifacts = {
       source: new codePipeline.Artifact('Source'),
-      build: new codePipeline.Artifact('BuildOutput')
+      githubSource: new codePipeline.Artifact('GithubSource'),
+      build: new codePipeline.Artifact('BuildOutput'),
+      githubBuild: new codePipeline.Artifact('GithubBuildOutput')
     };
+
+    const githubSecret =
+      secrets.Secret.fromSecretCompleteArn(this, 'github-access-token-secret', "arn:aws:secretsmanager:ap-northeast-1:139054167618:secret:NewestGithubPersonalAccessToken-HOm0Xx");
 
     const pipelineActions = {
       source: new codePipelineActions.CodeCommitSourceAction({
@@ -68,6 +92,27 @@ export class PipelineStack extends cdk.Stack {
         bucket: this.websiteAssetsS3Bucket,
         input: artifacts.build,
       }),
+
+      githubSource: new codePipelineActions.GitHubSourceAction({
+        actionName: "GithubCommit",
+        output: artifacts.githubSource,
+        owner: 'CallMeCCLemon',
+        repo: 'TheDailyAbstractionWebsiteAssets',
+        branch: 'main',
+        trigger: GitHubTrigger.WEBHOOK,
+        oauthToken: githubSecret.secretValue
+      }),
+      githubBuild: new codePipelineActions.CodeBuildAction({
+        actionName: 'CodeBuild',
+        project,
+        input: artifacts.githubSource,
+        outputs: [artifacts.githubBuild],
+      }),
+      githubDeploy: new codePipelineActions.S3DeployAction({
+        actionName: 'S3Deploy',
+        bucket: this.websiteAssetsS3Bucket,
+        input: artifacts.githubBuild,
+      }),
     };
 
     const pipeline = new codePipeline.Pipeline(this, 'blog-deploy-pipeline', {
@@ -76,6 +121,15 @@ export class PipelineStack extends cdk.Stack {
         {stageName: 'Source', actions: [pipelineActions.source]},
         {stageName: 'Build', actions: [pipelineActions.build]},
         {stageName: 'Deploy', actions: [pipelineActions.deploy]},
+      ],
+    });
+
+    const githubPipeline = new codePipeline.Pipeline(this, 'github-deploy-pipeline', {
+      pipelineName: `github-website-deploy-pipeline`,
+      stages: [
+        {stageName: 'GithubSource', actions: [pipelineActions.githubSource]},
+        {stageName: 'GithubBuild', actions: [pipelineActions.githubBuild]},
+        {stageName: 'GithubDeploy', actions: [pipelineActions.githubDeploy]},
       ],
     });
   }

--- a/lib/PipelineStack.ts
+++ b/lib/PipelineStack.ts
@@ -6,7 +6,6 @@ import * as codeCommit from 'aws-cdk-lib/aws-codecommit';
 import * as codePipelineActions from "aws-cdk-lib/aws-codepipeline-actions";
 import * as codeCommitActions from "aws-cdk-lib/aws-codepipeline-actions";
 import * as secrets from "aws-cdk-lib/aws-secretsmanager";
-import {GitHubTrigger} from "aws-cdk-lib/aws-codepipeline-actions";
 import * as cf from "aws-cdk-lib/aws-cloudfront";
 import {Construct} from "constructs";
 
@@ -94,22 +93,22 @@ export class PipelineStack extends cdk.Stack {
       }),
 
       githubSource: new codePipelineActions.GitHubSourceAction({
-        actionName: "GithubCommit",
+        actionName: "Github",
         output: artifacts.githubSource,
         owner: 'CallMeCCLemon',
         repo: 'TheDailyAbstractionWebsiteAssets',
         branch: 'main',
-        trigger: GitHubTrigger.WEBHOOK,
+        trigger: codePipelineActions.GitHubTrigger.WEBHOOK,
         oauthToken: githubSecret.secretValue
       }),
       githubBuild: new codePipelineActions.CodeBuildAction({
-        actionName: 'CodeBuild',
-        project,
+        actionName: 'GithubCodeBuild',
+        project: githubProject,
         input: artifacts.githubSource,
         outputs: [artifacts.githubBuild],
       }),
       githubDeploy: new codePipelineActions.S3DeployAction({
-        actionName: 'S3Deploy',
+        actionName: 'GithubS3Deploy',
         bucket: this.websiteAssetsS3Bucket,
         input: artifacts.githubBuild,
       }),

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blog_cdk",
+  "name": "the-daily-abstraction-cdk",
   "version": "0.1.0",
   "bin": {
     "personal_blog_cdk": "bin/blog_cdk.js"


### PR DESCRIPTION
### Notes
* Working on migration from CodeCommit to Github for source control
  * CodeCommit just doesn't yet have the same integrations and functionality as Github so we will begin using Github.
  * Was able to solve the OAuth issue I was previously having with github by using the AWS Console directly to link to Github. Created a personal access token and stored it in Secrets manager to allow code build/ code pipelines to pick up github events.
* Will be removing the codecommit artifacts in the next PR.

### Testing
`cdk diff` showed the exact changes I was wanting with this change. 