### PR TITLE
Moving Node CI/CD Pipeline to its own construct for re-usability

### DIFF
--- a/lib/BackendStack.ts
+++ b/lib/BackendStack.ts
@@ -1,0 +1,20 @@
+import * as cdk from "aws-cdk-lib";
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import {Construct} from "constructs";
+
+
+interface BackendStackProps extends cdk.StackProps {
+
+}
+
+export class BackendStack extends cdk.Stack {
+  public lambdaSourceBucket: s3.IBucket;
+
+  constructor(scope: Construct, id: string, props: BackendStackProps) {
+    super(scope, id, props);
+
+    this.lambdaSourceBucket = new s3.Bucket(this, 'lambda-source-bucket', {
+      accessControl: s3.BucketAccessControl.PRIVATE,
+    });
+  }
+}

--- a/lib/BlogStack.ts
+++ b/lib/BlogStack.ts
@@ -1,5 +1,5 @@
-import * as cdk from 'aws-cdk-lib';
 import {Construct} from 'constructs';
+import * as cdk from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as cf from "aws-cdk-lib/aws-cloudfront";
 import * as cfOrigin from "aws-cdk-lib/aws-cloudfront-origins";
@@ -8,7 +8,7 @@ import * as route53targets from "aws-cdk-lib/aws-route53-targets";
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import {HOSTED_ZONE_ID, HOSTED_ZONE_NAME, TOP_LEVEL_DOMAIN_CERTIFICATE_ARN} from "./constants";
 
-interface PersonalBlogStackProps extends cdk.StackProps {
+interface BlogStackProps extends cdk.StackProps {
 }
 
 export class BlogStack extends cdk.Stack {
@@ -18,7 +18,7 @@ export class BlogStack extends cdk.Stack {
 
   public topLevelHostedZone: route53.IHostedZone;
 
-  constructor(scope: Construct, id: string, props: PersonalBlogStackProps) {
+  constructor(scope: Construct, id: string, props: BlogStackProps) {
     super(scope, id, props);
 
     this.websiteAssetsS3Bucket = new s3.Bucket(this, 'blog-website-assets-bucket', {

--- a/lib/NodeCICDPipeline.ts
+++ b/lib/NodeCICDPipeline.ts
@@ -1,0 +1,116 @@
+import {Construct} from "constructs";
+import * as codebuild from "aws-cdk-lib/aws-codebuild";
+import * as codePipeline from "aws-cdk-lib/aws-codepipeline";
+import * as secrets from "aws-cdk-lib/aws-secretsmanager";
+import * as codePipelineActions from "aws-cdk-lib/aws-codepipeline-actions";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as cdk from "aws-cdk-lib";
+
+interface NodeCICDPipelineProps {
+  githubRepositoryName: string;
+  githubRepositoryOwner: string;
+  targetBranchName: string;
+  githubSecret: secrets.ISecret;
+  deploymentBucket: s3.IBucket;
+}
+
+export class NodeCICDPipeline extends Construct {
+  constructor(parent: Construct, id: string, props: NodeCICDPipelineProps) {
+    super(parent, id);
+
+    const githubSource = codebuild.Source.gitHub({
+      owner: props.githubRepositoryOwner,
+      repo: props.githubRepositoryName,
+      webhook: true,
+      branchOrRef: props.targetBranchName
+    });
+
+    const buildSpec = this.getBuildSpec();
+
+    const githubProject = new codebuild.Project(this, `${props.githubRepositoryName}-build-project`, {
+      source: githubSource,
+      environment: {
+        buildImage: codebuild.LinuxBuildImage.STANDARD_6_0,
+        privileged: true,
+        computeType: codebuild.ComputeType.SMALL,
+      },
+      timeout: cdk.Duration.minutes(30),
+      buildSpec
+    });
+
+    props.deploymentBucket.grantReadWrite(githubProject.grantPrincipal);
+
+    const artifacts = {
+      source: new codePipeline.Artifact(`${props.githubRepositoryName}Source`),
+      buildOutput: new codePipeline.Artifact(`${props.githubRepositoryName}BuildOutput`)
+    };
+
+    const pipelineActions = {
+      githubSource: new codePipelineActions.GitHubSourceAction({
+        actionName: "Github",
+        output: artifacts.source,
+        owner: props.githubRepositoryOwner,
+        repo: props.githubRepositoryName,
+        branch: props.targetBranchName,
+        trigger: codePipelineActions.GitHubTrigger.WEBHOOK,
+        oauthToken: props.githubSecret.secretValue
+      }),
+      githubBuild: new codePipelineActions.CodeBuildAction({
+        actionName: 'Build',
+        project: githubProject,
+        input: artifacts.source,
+        outputs: [artifacts.buildOutput],
+      }),
+      githubDeploy: new codePipelineActions.S3DeployAction({
+        actionName: 'Deploy',
+        bucket: props.deploymentBucket,
+        input: artifacts.buildOutput,
+      }),
+    };
+
+    const githubPipeline = new codePipeline.Pipeline(this, `${props.githubRepositoryName}-deployment-pipeline`, {
+      pipelineName: `${props.githubRepositoryName}-deployment-pipeline`,
+      stages: [
+        {stageName: 'Github', actions: [pipelineActions.githubSource]},
+        {stageName: 'Build', actions: [pipelineActions.githubBuild]},
+        {stageName: 'Deploy', actions: [pipelineActions.githubDeploy]},
+      ],
+    });
+  }
+
+  private getBuildSpec() {
+    return codebuild.BuildSpec.fromObject({
+      version: '0.2',
+      env: {
+        shell: 'bash'
+      },
+      phases: {
+        pre_build: {
+          commands: [
+            'echo Build started on `date`',
+            'aws --version',
+            'node --version',
+            'npm install',
+          ],
+        },
+        build: {
+          commands: [
+            'npm run build',
+          ],
+        },
+        post_build: {
+          commands: [
+            'echo Build completed on `date`',
+          ]
+        }
+      },
+      artifacts: {
+        ['base-directory']: 'build',
+        files: ['**/*']
+      },
+      cache: {
+        paths: ['node_modules/**/*']
+      }
+    })
+  }
+}

--- a/lib/PipelineStack.ts
+++ b/lib/PipelineStack.ts
@@ -1,115 +1,35 @@
 import * as cdk from "aws-cdk-lib";
-import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import * as s3 from "aws-cdk-lib/aws-s3";
-import * as codePipeline from "aws-cdk-lib/aws-codepipeline";
-import * as codeCommit from 'aws-cdk-lib/aws-codecommit';
-import * as codePipelineActions from "aws-cdk-lib/aws-codepipeline-actions";
 import * as secrets from "aws-cdk-lib/aws-secretsmanager";
 import {Construct} from "constructs";
-import * as cf from "aws-cdk-lib/aws-cloudfront";
+import {NodeCICDPipeline} from "./NodeCICDPipeline";
 
 interface PipelineStackProps extends cdk.StackProps {
   websiteAssetsS3Bucket: s3.IBucket;
+  lambdasS3Bucket: s3.IBucket;
 }
 
 export class PipelineStack extends cdk.Stack {
   constructor(parent: Construct, id: string, props: PipelineStackProps) {
     super(parent, id, props);
 
-    const githubSource = codebuild.Source.gitHub({
-      owner: 'CallMeCCLemon',
-      repo: 'TheDailyAbstractionWebsiteAssets',
-      webhook: true,
-      branchOrRef: 'main'
-    });
-
-    const buildSpec = this.getBuildSpec();
-
-    const githubProject = new codebuild.Project(this, 'github-website-assets-code-build-project', {
-      source: githubSource,
-      environment: {
-        buildImage: codebuild.LinuxBuildImage.STANDARD_6_0,
-        privileged: true,
-      },
-      buildSpec
-    });
-
-    props.websiteAssetsS3Bucket.grantReadWrite(githubProject.grantPrincipal);
-
-    const artifacts = {
-      githubSource: new codePipeline.Artifact('GithubSource'),
-      githubBuild: new codePipeline.Artifact('GithubBuildOutput')
-    };
-
     const githubSecret =
       secrets.Secret.fromSecretCompleteArn(this, 'github-access-token-secret', "arn:aws:secretsmanager:ap-northeast-1:139054167618:secret:NewestGithubPersonalAccessToken-HOm0Xx");
 
-    const pipelineActions = {
-      githubSource: new codePipelineActions.GitHubSourceAction({
-        actionName: "Github",
-        output: artifacts.githubSource,
-        owner: 'CallMeCCLemon',
-        repo: 'TheDailyAbstractionWebsiteAssets',
-        branch: 'main',
-        trigger: codePipelineActions.GitHubTrigger.WEBHOOK,
-        oauthToken: githubSecret.secretValue
-      }),
-      githubBuild: new codePipelineActions.CodeBuildAction({
-        actionName: 'GithubCodeBuild',
-        project: githubProject,
-        input: artifacts.githubSource,
-        outputs: [artifacts.githubBuild],
-      }),
-      githubDeploy: new codePipelineActions.S3DeployAction({
-        actionName: 'GithubS3Deploy',
-        bucket: props.websiteAssetsS3Bucket,
-        input: artifacts.githubBuild,
-      }),
-    };
-
-    const githubPipeline = new codePipeline.Pipeline(this, 'github-deploy-pipeline', {
-      pipelineName: `github-website-deploy-pipeline`,
-      stages: [
-        {stageName: 'GithubSource', actions: [pipelineActions.githubSource]},
-        {stageName: 'GithubBuild', actions: [pipelineActions.githubBuild]},
-        {stageName: 'GithubDeploy', actions: [pipelineActions.githubDeploy]},
-      ],
+    const websiteAssetsPipeline = new NodeCICDPipeline(this, 'website-assets-pipeline', {
+      githubRepositoryOwner: 'CallMeCCLemon',
+      githubRepositoryName: 'TheDailyAbstractionWebsiteAssets',
+      targetBranchName: 'main',
+      githubSecret: githubSecret,
+      deploymentBucket: props.websiteAssetsS3Bucket
     });
-  }
 
-  private getBuildSpec() {
-    return codebuild.BuildSpec.fromObject({
-      version: '0.2',
-      env: {
-        shell: 'bash'
-      },
-      phases: {
-        pre_build: {
-          commands: [
-            'echo Build started on `date`',
-            'aws --version',
-            'node --version',
-            'npm install',
-          ],
-        },
-        build: {
-          commands: [
-            'npm run build',
-          ],
-        },
-        post_build: {
-          commands: [
-            'echo Build completed on `date`',
-          ]
-        }
-      },
-      artifacts: {
-        ['base-directory']: 'build',
-        files: ['**/*']
-      },
-      cache: {
-        paths: ['node_modules/**/*']
-      }
-    })
+    const lambdaDeploymentPipeline = new NodeCICDPipeline(this, 'lambda-assets-pipeline', {
+      githubRepositoryOwner: 'CallMeCCLemon',
+      githubRepositoryName: 'TheDailyAbstractionLambdas',
+      targetBranchName: 'main',
+      githubSecret: githubSecret,
+      deploymentBucket: props.lambdasS3Bucket
+    });
   }
 }

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -3,6 +3,7 @@ import {BlogStack} from "./BlogStack";
 import {PipelineStack} from "./PipelineStack";
 import {UserPoolStack} from "./UserPoolStack";
 import {AWS_ACCOUNT_ID, DEFAULT_REGION} from "./constants";
+import {BackendStack} from "./BackendStack";
 
 const app = new cdk.App({
 });
@@ -16,14 +17,19 @@ const blogStack = new BlogStack(app, 'blog-stack', {
   env: env
 });
 
-const pipelineStack = new PipelineStack(app, 'pipeline-stack', {
-  env: env,
-  websiteAssetsS3Bucket: blogStack.websiteAssetsS3Bucket,
-});
-
 const userPoolStack = new UserPoolStack(app, 'user-pool-stack', {
   rootHostedZone: blogStack.topLevelHostedZone
 });
 userPoolStack.addDependency(blogStack);
+
+const backendStack = new BackendStack(app, 'backend-stack', {
+  env: env
+})
+
+const pipelineStack = new PipelineStack(app, 'pipeline-stack', {
+  env: env,
+  websiteAssetsS3Bucket: blogStack.websiteAssetsS3Bucket,
+  lambdasS3Bucket: backendStack.lambdaSourceBucket,
+});
 
 app.synth();


### PR DESCRIPTION
### Notes

* I needed to largely re-use the CI/CD pipeline declarations which were in-use from the React application's deployment strategy so I moved it to a common Construct.
* One of the most useful parts of working with CDK (and infrastructure as code) is the ability to re-use the code for consistent infrastructure deployments. I have defined it once and am able to use it as many times as I need now as long as it's a node library.

### Testing
CDK diff showed what I was looking for and the deployment succeeded.