### PR TITLE
Adding OpenAPI Deployment logic for API Gateway

### DIFF
--- a/lib/BackendStack.ts
+++ b/lib/BackendStack.ts
@@ -1,6 +1,11 @@
 import * as cdk from "aws-cdk-lib";
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as apig from 'aws-cdk-lib/aws-apigateway';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import {Construct} from "constructs";
+import {API_DEFINITION_KEY, API_DOMAIN_CERTIFICATE_ARN, HOSTED_ZONE_NAME, LAMBDA_OUTPUT_KEY} from "./constants";
 
 
 interface BackendStackProps extends cdk.StackProps {
@@ -9,6 +14,7 @@ interface BackendStackProps extends cdk.StackProps {
 
 export class BackendStack extends cdk.Stack {
   public lambdaSourceBucket: s3.IBucket;
+  public lambdaFunction: lambda.IFunction;
 
   constructor(scope: Construct, id: string, props: BackendStackProps) {
     super(scope, id, props);
@@ -16,5 +22,32 @@ export class BackendStack extends cdk.Stack {
     this.lambdaSourceBucket = new s3.Bucket(this, 'lambda-source-bucket', {
       accessControl: s3.BucketAccessControl.PRIVATE,
     });
+
+    this.lambdaFunction = new lambda.Function(this, 'backend-lambda-function', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: 'TestLambda/index.handler',
+      code: lambda.Code.fromBucket(this.lambdaSourceBucket, LAMBDA_OUTPUT_KEY),
+      timeout: cdk.Duration.minutes(1),
+      memorySize: 128,
+      logRetention: logs.RetentionDays.ONE_MONTH,
+    });
+
+    const apiGatewayCert = acm.Certificate.fromCertificateArn(this, 'api-domain-cert', API_DOMAIN_CERTIFICATE_ARN);
+    const assetDefinition = apig.AssetApiDefinition.fromBucket(this.lambdaSourceBucket, API_DEFINITION_KEY);
+
+    // const apiGateway = new apig.LambdaRestApi(this, 'backend-api-gateway', {
+    //   handler: this.lambdaFunction,
+    //   proxy: true,
+    //   deploy: true,
+    //   retainDeployments: true,
+    //   domainName: {
+    //     domainName: `api.${HOSTED_ZONE_NAME}`,
+    //     certificate: apiGatewayCert,
+    //   },
+    //   integrationOptions: {
+    //     proxy: true,
+    //
+    //   }
+    // });
   }
 }

--- a/lib/PipelineStack.ts
+++ b/lib/PipelineStack.ts
@@ -38,15 +38,5 @@ export class PipelineStack extends cdk.Stack {
       buildSpec: LAMBDA_PACKAGE_BUILD_SPEC,
       apiBuildSpec: SMITHY_MODEL_BUILD_SPEC,
     });
-
-    // const apiGatewayDeploymentPipeline = new NodeCICDPipeline(this, 'api-gateway-model-pipeline', {
-    //   githubRepositoryOwner: 'CallMeCCLemon',
-    //   githubRepositoryName: 'TheDailyAbstractionLambdas',
-    //   targetBranchName: 'main',
-    //   githubSecret: githubSecret,
-    //   deploymentBucket: props.lambdasS3Bucket,
-    //   extractZipBeforeDeploying: true,
-    //   buildSpec: SMITHY_MODEL_BUILD_SPEC,
-    // });
   }
 }

--- a/lib/PipelineStack.ts
+++ b/lib/PipelineStack.ts
@@ -3,6 +3,8 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import * as secrets from "aws-cdk-lib/aws-secretsmanager";
 import {Construct} from "constructs";
 import {NodeCICDPipeline} from "./NodeCICDPipeline";
+import {LAMBDA_OUTPUT_KEY} from "./constants";
+import {LAMBDA_PACKAGE_BUILD_SPEC, SMITHY_MODEL_BUILD_SPEC} from "./buildSpec/LambdaPackageBuildSpec";
 
 interface PipelineStackProps extends cdk.StackProps {
   websiteAssetsS3Bucket: s3.IBucket;
@@ -21,7 +23,8 @@ export class PipelineStack extends cdk.Stack {
       githubRepositoryName: 'TheDailyAbstractionWebsiteAssets',
       targetBranchName: 'main',
       githubSecret: githubSecret,
-      deploymentBucket: props.websiteAssetsS3Bucket
+      deploymentBucket: props.websiteAssetsS3Bucket,
+      extractZipBeforeDeploying: true,
     });
 
     const lambdaDeploymentPipeline = new NodeCICDPipeline(this, 'lambda-assets-pipeline', {
@@ -29,7 +32,21 @@ export class PipelineStack extends cdk.Stack {
       githubRepositoryName: 'TheDailyAbstractionLambdas',
       targetBranchName: 'main',
       githubSecret: githubSecret,
-      deploymentBucket: props.lambdasS3Bucket
+      deploymentBucket: props.lambdasS3Bucket,
+      extractZipBeforeDeploying: false,
+      outputObjectKey: LAMBDA_OUTPUT_KEY,
+      buildSpec: LAMBDA_PACKAGE_BUILD_SPEC,
+      apiBuildSpec: SMITHY_MODEL_BUILD_SPEC,
     });
+
+    // const apiGatewayDeploymentPipeline = new NodeCICDPipeline(this, 'api-gateway-model-pipeline', {
+    //   githubRepositoryOwner: 'CallMeCCLemon',
+    //   githubRepositoryName: 'TheDailyAbstractionLambdas',
+    //   targetBranchName: 'main',
+    //   githubSecret: githubSecret,
+    //   deploymentBucket: props.lambdasS3Bucket,
+    //   extractZipBeforeDeploying: true,
+    //   buildSpec: SMITHY_MODEL_BUILD_SPEC,
+    // });
   }
 }

--- a/lib/buildSpec/LambdaPackageBuildSpec.ts
+++ b/lib/buildSpec/LambdaPackageBuildSpec.ts
@@ -1,0 +1,75 @@
+import * as codebuild from "aws-cdk-lib/aws-codebuild";
+
+export const LAMBDA_PACKAGE_BUILD_SPEC = codebuild.BuildSpec.fromObject({
+  version: '0.2',
+  env: {
+    shell: 'bash'
+  },
+  phases: {
+    pre_build: {
+      commands: [
+        'echo Build started on `date`',
+        'aws --version',
+        'gradle --version',
+        'node --version',
+        'npm install',
+      ],
+    },
+    build: {
+      commands: [
+        './gradlew build',
+        'npm run build',
+      ],
+    },
+    post_build: {
+      commands: [
+        'echo Build completed on `date`',
+      ]
+    }
+  },
+  artifacts: {
+    // ['base-directory']: 'build',
+    files: [
+      'build/**/*',
+      'server/codegen/build/smithyprojections/codegen/apigateway/openapi/TheDailyAbstractionGateway.openapi.json'
+    ]
+  },
+  cache: {
+    paths: ['node_modules/**/*']
+  }
+});
+
+export const SMITHY_MODEL_BUILD_SPEC = codebuild.BuildSpec.fromObject({
+  version: '0.2',
+  env: {
+    shell: 'bash'
+  },
+  phases: {
+    pre_build: {
+      commands: [
+        'echo Build started on `date`',
+        'aws --version',
+        'gradle --version',
+      ],
+    },
+    build: {
+      commands: [
+        './gradlew build',
+      ],
+    },
+    post_build: {
+      commands: [
+        'echo Build completed on `date`',
+      ]
+    }
+  },
+  artifacts: {
+    // ['base-directory']: 'build',
+    'discard-paths': true,
+    files: [
+      'server/codegen/build/smithyprojections/codegen/apigateway/openapi/*'
+    ]
+  },
+  cache: {
+  }
+});

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,8 +3,11 @@ export const HOSTED_ZONE_ID = "Z07017043O2D69FLW48LN";
 
 export const TOP_LEVEL_DOMAIN_CERTIFICATE_ARN = 'arn:aws:acm:us-east-1:139054167618:certificate/aac754cf-b9a9-40ae-89bc-735e03897092';
 export const AUTH_DOMAIN_CERTIFICATE_ARN = 'arn:aws:acm:us-east-1:139054167618:certificate/3e05b23c-3136-41e5-b21e-40faaea38bfe';
-
-export const CHATBOT_SLACK_CONFIGURATION_ARN = 'arn:aws:chatbot::139054167618:chat-configuration/slack-channel/pr-notifications-configuration';
+export const API_DOMAIN_CERTIFICATE_ARN = 'arn:aws:acm:ap-northeast-1:139054167618:certificate/5d0f4190-ac97-4658-a6ca-2873c9629390';
 
 export const AWS_ACCOUNT_ID = '139054167618';
 export const DEFAULT_REGION = 'ap-northeast-1';
+
+export const LAMBDA_OUTPUT_KEY = "lambda.zip";
+
+export const API_DEFINITION_KEY = "TheDailyAbstractionGateway.openapi.json";


### PR DESCRIPTION
### Notes
* Added lambda function to pick up the deployed Node functions.
* Added build step to build and deploy a Smithy API model to S3 for API Gateway to pick up in the next change.
* Added buildSpecs for different types of projects which we will use for this project.

### Testing
cdk diff and deploy were verified.